### PR TITLE
[GEF] Convert PropertyTable to GEF GraphicalViewer

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/ConstantSelectionPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/ConstantSelectionPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,6 +35,7 @@ import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.core.utils.ui.dialogs.ResizableDialog;
 
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IJavaProject;
@@ -65,7 +66,6 @@ import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/DisplayExpressionPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/DisplayExpressionPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,8 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.jdt.core.dom.Expression;
-import org.eclipse.swt.graphics.Point;
 
 /**
  * {@link PropertyEditor} that displays source of {@link Expression} from {@link GenericProperty}.

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/InnerClassPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/InnerClassPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,13 +30,13 @@ import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 import org.eclipse.wb.internal.core.utils.ui.UiUtils;
 
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Shell;
 
 import org.apache.commons.lang3.StringUtils;

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/complex/InstanceObjectPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/complex/InstanceObjectPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,6 +37,7 @@ import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
@@ -48,7 +49,6 @@ import org.eclipse.jdt.ui.IJavaElementSearchConstants;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.window.Window;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.dialogs.SelectionDialog;
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/string/StringPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/string/StringPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -92,7 +92,7 @@ public class StringPropertyEditor extends AbstractTextPropertyEditor {
 	 * Opens editing dialog.
 	 */
 	private void openDialog(PropertyTable propertyTable, Property property) throws Exception {
-		StringPropertyDialog dialog = new StringPropertyDialog(propertyTable.getShell(), property);
+		StringPropertyDialog dialog = new StringPropertyDialog(propertyTable.getControl().getShell(), property);
 		if (dialog.open() == Window.OK) {
 		}
 	}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerMethodPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerMethodPropertyEditor.java
@@ -18,7 +18,7 @@ import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 
-import org.eclipse.swt.graphics.Point;
+import org.eclipse.draw2d.geometry.Point;
 
 /**
  * Implementation of {@link PropertyEditor} for {@link ListenerMethodProperty}.

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/ImportantPropertiesDialog.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/ImportantPropertiesDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -92,7 +92,7 @@ public class ImportantPropertiesDialog extends ResizableDialog {
 	private final ObjectEventListener m_refreshListener = new ObjectEventListener() {
 		@Override
 		public void refreshed() throws Exception {
-			m_propertyTable.redraw();
+			m_propertyTable.getControl().redraw();
 		}
 	};
 
@@ -102,7 +102,7 @@ public class ImportantPropertiesDialog extends ResizableDialog {
 		area.setLayout(new GridLayout());
 		//
 		m_propertyTable = new PropertyTable(area, SWT.BORDER);
-		GridDataFactory.create(m_propertyTable).grab().fill().hintC(55, 20);
+		GridDataFactory.create(m_propertyTable.getControl()).grab().fill().hintC(55, 20);
 		// install refresh listener
 		m_javaInfo.addBroadcastListener(m_refreshListener);
 		// show important properties

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/FigureCanvas.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/FigureCanvas.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,10 +11,9 @@
 package org.eclipse.wb.internal.draw2d;
 
 import org.eclipse.wb.draw2d.Figure;
-import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
+import org.eclipse.draw2d.DeferredUpdateManager;
 import org.eclipse.draw2d.Graphics;
-import org.eclipse.draw2d.LightweightSystem;
 import org.eclipse.draw2d.SWTGraphics;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -23,8 +22,6 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Listener;
 
 /**
  * A Canvas that contains {@link Figure Figures}.
@@ -35,11 +32,7 @@ import org.eclipse.swt.widgets.Listener;
 public class FigureCanvas extends org.eclipse.draw2d.FigureCanvas {
 	private RootFigure m_rootFigure;
 	private final Dimension m_rootPreferredSize = new Dimension();
-	// TODO ptziegler: Painting the figures on the canvas is the responsibility of
-	// the UpdateManager, not the FigureCanvas.
-	@Deprecated
-	private Image m_bufferedImage;
-	private boolean m_drawCached;
+	private CachedUpdateManager m_updateManager;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -47,9 +40,7 @@ public class FigureCanvas extends org.eclipse.draw2d.FigureCanvas {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public FigureCanvas(Composite parent, int style) {
-		super(parent, style | SWT.NO_BACKGROUND | SWT.NO_REDRAW_RESIZE, createLightweightSystem());
-		// add all listeners
-		hookControlEvents();
+		super(parent, style | SWT.NO_BACKGROUND | SWT.NO_REDRAW_RESIZE);
 		// create root figure
 		createRootFigure();
 	}
@@ -66,38 +57,17 @@ public class FigureCanvas extends org.eclipse.draw2d.FigureCanvas {
 		m_rootFigure.setForegroundColor(getForeground());
 		m_rootFigure.setFont(getFont());
 		setDefaultEventManager();
+		setDefaultUpdateManager();
 		setContents(m_rootFigure);
-	}
-
-	private static LightweightSystem createLightweightSystem() {
-		return new LightweightSystem() {
-			private FigureCanvas getFigureCanvas() {
-				return (FigureCanvas) ReflectionUtils.getFieldObject(this, "canvas");
-			}
-
-			@Override
-			protected void controlResized() {
-				getFigureCanvas().disposeBufferedImage();
-				super.controlResized();
-			}
-
-			@Override
-			public void paint(GC gc) {
-				org.eclipse.swt.graphics.Rectangle bounds = gc.getClipping();
-				getFigureCanvas().handlePaint(gc, bounds.x, bounds.y, bounds.width, bounds.height);
-			}
-		};
 	}
 
 	protected void setDefaultEventManager() {
 		m_rootFigure.getFigureCanvas().getLightweightSystem().setEventDispatcher(new EventManager(this));
 	}
 
-	private void disposeBufferedImage() {
-		if (m_bufferedImage != null) {
-			m_bufferedImage.dispose();
-			m_bufferedImage = null;
-		}
+	protected void setDefaultUpdateManager() {
+		m_updateManager = new CachedUpdateManager(this);
+		m_rootFigure.getFigureCanvas().getLightweightSystem().setUpdateManager(m_updateManager);
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -117,7 +87,7 @@ public class FigureCanvas extends org.eclipse.draw2d.FigureCanvas {
 	 * Sets draw cached mode.
 	 */
 	public void setDrawCached(boolean value) {
-		m_drawCached = value;
+		m_updateManager.m_drawCached = value;
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -136,52 +106,6 @@ public class FigureCanvas extends org.eclipse.draw2d.FigureCanvas {
 	// Handle events
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private void hookControlEvents() {
-		addListener(SWT.Dispose, new Listener() {
-			@Override
-			public void handleEvent(Event event) {
-				disposeBufferedImage();
-			}
-		});
-	}
-
-	private void handlePaint(GC paintGC, int x, int y, int width, int height) {
-		// check draw cached mode
-		if (m_drawCached) {
-			if (m_bufferedImage == null) {
-				paintGC.fillRectangle(x, y, width, height);
-			} else {
-				paintGC.drawImage(m_bufferedImage, 0, 0);
-			}
-			return;
-		}
-		// check double buffered image
-		if (m_bufferedImage == null) {
-			Point size = getSize();
-			m_bufferedImage = new Image(null, size.x, size.y);
-		}
-		// prepare double buffered Graphics
-		GC bufferedGC = new GC(m_bufferedImage);
-		try {
-			bufferedGC.setClipping(x, y, width, height);
-			bufferedGC.setBackground(paintGC.getBackground());
-			bufferedGC.setForeground(paintGC.getForeground());
-			bufferedGC.setFont(paintGC.getFont());
-			bufferedGC.setLineStyle(paintGC.getLineStyle());
-			bufferedGC.setLineWidth(paintGC.getLineWidth());
-			bufferedGC.setXORMode(paintGC.getXORMode());
-			// draw content
-			Graphics graphics = new SWTGraphics(bufferedGC);
-			int dx = -getViewport().getHorizontalRangeModel().getValue();
-			int dy = -getViewport().getVerticalRangeModel().getValue();
-			graphics.translate(dx, dy);
-			m_rootFigure.paint(graphics);
-		} finally {
-			bufferedGC.dispose();
-		}
-		// flush painting
-		paintGC.drawImage(m_bufferedImage, 0, 0);
-	}
 
 	/**
 	 * Check bounds and reconfigure scroll bar's if needed and repaint client area.
@@ -202,6 +126,64 @@ public class FigureCanvas extends org.eclipse.draw2d.FigureCanvas {
 			getViewport().revalidate();
 			// set repaint
 			redraw();
+		}
+	}
+
+	private static class CachedUpdateManager extends DeferredUpdateManager {
+		private FigureCanvas m_canvas;
+		private Image m_bufferedImage;
+		private boolean m_drawCached;
+
+		public CachedUpdateManager(FigureCanvas canvas) {
+			m_canvas = canvas;
+		}
+
+		@Override
+		protected void paint(GC paintGC) {
+			org.eclipse.swt.graphics.Rectangle bounds = paintGC.getClipping();
+			// check draw cached mode
+			if (m_drawCached) {
+				if (m_bufferedImage == null) {
+					paintGC.fillRectangle(bounds);
+				} else {
+					paintGC.drawImage(m_bufferedImage, 0, 0);
+				}
+				return;
+			}
+			// check double buffered image
+			if (m_bufferedImage == null) {
+				Point size = m_canvas.getSize();
+				m_bufferedImage = new Image(null, size.x, size.y);
+			}
+			// prepare double buffered Graphics
+			GC bufferedGC = new GC(m_bufferedImage);
+			try {
+				bufferedGC.setClipping(bounds);
+				bufferedGC.setBackground(paintGC.getBackground());
+				bufferedGC.setForeground(paintGC.getForeground());
+				bufferedGC.setFont(paintGC.getFont());
+				bufferedGC.setLineStyle(paintGC.getLineStyle());
+				bufferedGC.setLineWidth(paintGC.getLineWidth());
+				bufferedGC.setXORMode(paintGC.getXORMode());
+				// draw content
+				Graphics graphics = new SWTGraphics(bufferedGC);
+				int dx = -m_canvas.getViewport().getHorizontalRangeModel().getValue();
+				int dy = -m_canvas.getViewport().getVerticalRangeModel().getValue();
+				graphics.translate(dx, dy);
+				m_canvas.getRootFigure().paint(graphics);
+			} finally {
+				bufferedGC.dispose();
+			}
+			// flush painting
+			paintGC.drawImage(m_bufferedImage, 0, 0);
+		}
+
+		@Override
+		public void dispose() {
+			if (m_bufferedImage != null) {
+				m_bufferedImage.dispose();
+				m_bufferedImage = null;
+			}
 		}
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/structure/property/ComponentsPropertiesPage.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/structure/property/ComponentsPropertiesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -111,7 +111,7 @@ public final class ComponentsPropertiesPage implements IPage {
 		}
 		// show "properties" table
 		{
-			m_stackLayout.topControl = m_propertyTable;
+			m_stackLayout.topControl = m_propertyTable.getControl();
 			m_container.layout();
 		}
 		// actions
@@ -237,7 +237,7 @@ public final class ComponentsPropertiesPage implements IPage {
 				}
 			}
 		});
-		m_propertyTable.setMenu(manager.createContextMenu(m_propertyTable));
+		m_propertyTable.getControl().setMenu(manager.createContextMenu(m_propertyTable.getControl()));
 	}
 
 	/**
@@ -419,7 +419,7 @@ public final class ComponentsPropertiesPage implements IPage {
 		@Override
 		public void run() {
 			PropertyManager.setCategory(m_activeProperty, m_category);
-			m_propertyTable.redraw();
+			m_propertyTable.getControl().redraw();
 		}
 
 		private void update() {
@@ -482,9 +482,9 @@ public final class ComponentsPropertiesPage implements IPage {
 				refreshProperties();
 				// set focus
 				if (m_showEvents) {
-					m_eventsTable.setFocus();
+					m_eventsTable.getControl().setFocus();
 				} else {
-					m_propertyTable.setFocus();
+					m_propertyTable.getControl().setFocus();
 				}
 			}
 		};
@@ -534,7 +534,7 @@ public final class ComponentsPropertiesPage implements IPage {
 		m_eventsTable.setInput(properties);
 		// show "events" table
 		{
-			m_stackLayout.topControl = m_eventsTable;
+			m_stackLayout.topControl = m_eventsTable.getControl();
 			m_container.layout();
 		}
 	}
@@ -553,7 +553,7 @@ public final class ComponentsPropertiesPage implements IPage {
 		}
 		// show "property" table
 		{
-			m_stackLayout.topControl = m_propertyTable;
+			m_stackLayout.topControl = m_propertyTable.getControl();
 			m_container.layout();
 		}
 	}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/ComplexProperty.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/ComplexProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTooltipProvider;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTooltipTextProvider;
 
-import org.eclipse.swt.graphics.Point;
+import org.eclipse.draw2d.geometry.Point;
 
 import java.util.List;
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractComboBoxPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractComboBoxPropertyEditor.java
@@ -15,7 +15,6 @@ import org.eclipse.wb.core.controls.CComboBox;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.swt.SWT;
@@ -74,15 +73,12 @@ public abstract class AbstractComboBoxPropertyEditor extends TextDisplayProperty
 		});
 		m_combo.setFocus();
 		// schedule showing drop-down, because we don't have bounds yet
-		ExecutionUtils.runAsync(new RunnableEx() {
-			@Override
-			public void run() throws Exception {
-				m_combo.comboDropDown(true);
-				if (m_dropDelayedText != null) {
-					m_combo.setEditText(m_dropDelayedText);
-					m_combo.setEditSelection(m_dropDelayedText.length(), m_dropDelayedText.length());
-					m_dropDelayedText = null;
-				}
+		ExecutionUtils.runAsync(() -> {
+			m_combo.comboDropDown(true);
+			if (m_dropDelayedText != null) {
+				m_combo.setEditText(m_dropDelayedText);
+				m_combo.setEditSelection(m_dropDelayedText.length(), m_dropDelayedText.length());
+				m_dropDelayedText = null;
 			}
 		});
 		// keep editor active
@@ -95,7 +91,7 @@ public abstract class AbstractComboBoxPropertyEditor extends TextDisplayProperty
 		} else if (e.keyCode == SWT.ARROW_UP || e.keyCode == SWT.ARROW_DOWN) {
 			e.doit = false;
 			propertyTable.deactivateEditor(true);
-			propertyTable.navigate(e);
+			propertyTable.getEditDomain().navigate(e);
 		}
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractComboBoxPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractComboBoxPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,7 +49,7 @@ public abstract class AbstractComboBoxPropertyEditor extends TextDisplayProperty
 	public final boolean activate(final PropertyTable propertyTable,
 			final Property property,
 			Point location) throws Exception {
-		m_combo = new CComboBox(propertyTable, SWT.NONE);
+		m_combo = new CComboBox(propertyTable.getControl(), SWT.NONE);
 		// initialize
 		addItems(property, m_combo);
 		selectItem(property, m_combo);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractComboBoxPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractComboBoxPropertyEditor.java
@@ -17,6 +17,7 @@ import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusAdapter;
 import org.eclipse.swt.events.FocusEvent;
@@ -24,7 +25,6 @@ import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 
 /**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractComboPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractComboPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -46,7 +46,7 @@ public abstract class AbstractComboPropertyEditor extends TextDisplayPropertyEdi
 			throws Exception {
 		// create combo
 		{
-			m_combo = new CCombo3(propertyTable, SWT.NONE);
+			m_combo = new CCombo3(propertyTable.getControl(), SWT.NONE);
 			m_doDropDown = true;
 			// add items
 			addItems(property, m_combo);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractComboPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractComboPropertyEditor.java
@@ -14,6 +14,7 @@ import org.eclipse.wb.core.controls.CCombo3;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusAdapter;
 import org.eclipse.swt.events.FocusEvent;
@@ -21,7 +22,6 @@ import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractTextPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractTextPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,7 +44,7 @@ public abstract class AbstractTextPropertyEditor extends TextDisplayPropertyEdit
 			Point location) throws Exception {
 		// create Text
 		{
-			m_textControl = new Text(propertyTable, SWT.NONE);
+			m_textControl = new Text(propertyTable.getControl(), SWT.NONE);
 			new TextControlActionsManager(m_textControl);
 			m_textControl.setEditable(isEditable());
 			m_textControl.setFocus();

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractTextPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractTextPropertyEditor.java
@@ -143,7 +143,7 @@ public abstract class AbstractTextPropertyEditor extends TextDisplayPropertyEdit
 			}
 			// OK, deactivate and navigate
 			propertyTable.deactivateEditor(true);
-			propertyTable.navigate(e);
+			propertyTable.getEditDomain().navigate(e);
 		}
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractTextPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/AbstractTextPropertyEditor.java
@@ -13,11 +13,11 @@ package org.eclipse.wb.internal.core.model.property.editor;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.KeyListener;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/BooleanObjectPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/BooleanObjectPropertyEditor.java
@@ -16,8 +16,8 @@ import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.utils.ui.DrawUtils;
 
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.Point;
 
 /**
  * The {@link PropertyEditor} for <code>Boolean</code>.

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/BooleanPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/BooleanPropertyEditor.java
@@ -16,8 +16,8 @@ import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.utils.ui.DrawUtils;
 
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.Point;
 
 /**
  * The {@link PropertyEditor} for <code>boolean</code>.

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/PropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/PropertyEditor.java
@@ -16,10 +16,10 @@ import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.utils.IAdaptable;
 
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.graphics.GC;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/TextDialogPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/TextDialogPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.wb.internal.core.model.property.editor.presentation.ButtonPro
 import org.eclipse.wb.internal.core.model.property.editor.presentation.PropertyEditorPresentation;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 
-import org.eclipse.swt.graphics.Point;
+import org.eclipse.draw2d.geometry.Point;
 
 /**
  * Abstract {@link PropertyEditor} that displays text and button to open dialog.

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/ButtonPropertyEditorPresentationImpl.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/ButtonPropertyEditorPresentationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -103,7 +103,7 @@ class ButtonPropertyEditorPresentationImpl extends PropertyEditorPresentation {
 			propertyTable.setActiveProperty(property);
 		});
 		// return focus on propertyTable after click
-		control.addListener(SWT.MouseUp, event -> propertyTable.forceFocus());
+		control.addListener(SWT.MouseUp, event -> propertyTable.getControl().forceFocus());
 		// handle selection
 		control.addListener(SWT.Selection, event -> {
 			try {
@@ -120,7 +120,7 @@ class ButtonPropertyEditorPresentationImpl extends PropertyEditorPresentation {
 	 * Creates the {@link Control} instance. By default, {@link Button} instance created.
 	 */
 	protected Control createControlImpl(final PropertyTable propertyTable, final Property property) {
-		Button button = new Button(propertyTable, getPresentation().getStyle());
+		Button button = new Button(propertyTable.getControl(), getPresentation().getStyle());
 		button.setImage(getPresentation().getImage());
 		button.setToolTipText(getPresentation().getTooltip());
 		return button;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/ButtonPropertyEditorPresentationImpl.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/ButtonPropertyEditorPresentationImpl.java
@@ -15,6 +15,7 @@ import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.utils.Pair;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Control;
@@ -171,11 +172,14 @@ class ButtonPropertyEditorPresentationImpl extends PropertyEditorPresentation {
 		control.setData("oldWidth", newWidth);
 		control.setData("oldHeight", newHeight);
 		// check, may be same size
-		if (oldWidthObject != null) {
+		if (oldWidthObject != null && oldHeightObject != null) {
 			int oldWidth = oldWidthObject.intValue();
 			int oldHeight = oldHeightObject.intValue();
 			if (oldWidth == newWidth && oldHeight == newHeight) {
-				control.setLocation(newX, newY);
+				Point newLocation = new Point(newX, newY);
+				if (!newLocation.equals(control.getLocation())) {
+					control.setLocation(newLocation);
+				}
 				return;
 			}
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/ButtonPropertyEditorPresentationImplMac.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/ButtonPropertyEditorPresentationImplMac.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -41,7 +41,7 @@ final class ButtonPropertyEditorPresentationImplMac extends ButtonPropertyEditor
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected final Control createControlImpl(final PropertyTable propertyTable, Property property) {
-		CFlatButton button = new CFlatButton(propertyTable, SWT.NONE);
+		CFlatButton button = new CFlatButton(propertyTable.getControl(), SWT.NONE);
 		button.setImage(getPresentation().getImage());
 		button.setToolTipText(getPresentation().getTooltip());
 		return button;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
@@ -44,7 +44,6 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
@@ -500,7 +499,7 @@ public class PropertyTable extends GraphicalViewerImpl {
 	 * @param location the mouse location, if editor is activated using mouse click,
 	 *                 or <code>null</code> if it is activated using keyboard.
 	 */
-	public void activateEditor(Property property, Point location) {
+	public void activateEditor(Property property, org.eclipse.swt.graphics.Point location) {
 		try {
 			// de-activate old editor
 			deactivateEditor(true);
@@ -701,8 +700,8 @@ public class PropertyTable extends GraphicalViewerImpl {
 	 *
 	 * @return the location relative to the value part of property.
 	 */
-	private Point getValueRelativeLocation(int x, int y) {
-		return new Point(x - (m_splitter + 2), y - m_rowHeight * getPropertyIndex(y));
+	private org.eclipse.swt.graphics.Point getValueRelativeLocation(int x, int y) {
+		return new org.eclipse.swt.graphics.Point(x - (m_splitter + 2), y - m_rowHeight * getPropertyIndex(y));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -859,13 +858,13 @@ public class PropertyTable extends GraphicalViewerImpl {
 	/**
 	 * @return the location of state image (plus/minus) for given {@link Property}.
 	 */
-	public Point forTests_getStateLocation(Property property) {
+	public org.eclipse.swt.graphics.Point forTests_getStateLocation(Property property) {
 		PropertyInfo propertyInfo = getPropertyInfo(property);
 		if (propertyInfo != null) {
 			int index = m_properties.indexOf(propertyInfo);
 			int x = getTitleX(propertyInfo);
 			int y = m_rowHeight * (index - m_selection) + 1;
-			return new Point(x, y);
+			return new org.eclipse.swt.graphics.Point(x, y);
 		}
 		return null;
 	}
@@ -873,13 +872,13 @@ public class PropertyTable extends GraphicalViewerImpl {
 	/**
 	 * @return the location of state image (plus/minus) for given {@link Property}.
 	 */
-	public Point forTests_getValueLocation(Property property) {
+	public org.eclipse.swt.graphics.Point forTests_getValueLocation(Property property) {
 		PropertyInfo propertyInfo = getPropertyInfo(property);
 		if (propertyInfo != null) {
 			int index = m_properties.indexOf(propertyInfo);
 			int x = m_splitter + 5;
 			int y = m_rowHeight * (index - m_selection) + 1;
-			return new Point(x, y);
+			return new org.eclipse.swt.graphics.Point(x, y);
 		}
 		return null;
 	}
@@ -1002,7 +1001,7 @@ public class PropertyTable extends GraphicalViewerImpl {
 			setActiveEditorBounds();
 			// prepare buffered image
 			if (m_bufferedImage == null || m_bufferedImage.isDisposed()) {
-				Point size = getControl().getSize();
+				org.eclipse.swt.graphics.Point size = getControl().getSize();
 				m_bufferedImage = new Image(DesignerPlugin.getStandardDisplay(), size.x, size.y);
 			}
 			// prepare buffered GC

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
@@ -28,6 +28,7 @@ import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.SWTGraphics;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.ui.parts.GraphicalViewerImpl;
 import org.eclipse.jface.viewers.ISelection;
@@ -499,7 +500,7 @@ public class PropertyTable extends GraphicalViewerImpl {
 	 * @param location the mouse location, if editor is activated using mouse click,
 	 *                 or <code>null</code> if it is activated using keyboard.
 	 */
-	public void activateEditor(Property property, org.eclipse.swt.graphics.Point location) {
+	public void activateEditor(Property property, Point location) {
 		try {
 			// de-activate old editor
 			deactivateEditor(true);
@@ -700,8 +701,8 @@ public class PropertyTable extends GraphicalViewerImpl {
 	 *
 	 * @return the location relative to the value part of property.
 	 */
-	private org.eclipse.swt.graphics.Point getValueRelativeLocation(int x, int y) {
-		return new org.eclipse.swt.graphics.Point(x - (m_splitter + 2), y - m_rowHeight * getPropertyIndex(y));
+	private Point getValueRelativeLocation(int x, int y) {
+		return new Point(x - (m_splitter + 2), y - m_rowHeight * getPropertyIndex(y));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
@@ -35,6 +35,7 @@ import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.MouseAdapter;
@@ -116,6 +117,9 @@ public class PropertyTable extends GraphicalViewerImpl {
 	private int m_selection;
 	private int m_page;
 	private int m_splitter = -1;
+	private Font m_baseFont;
+	private Font m_boldFont;
+	private Font m_italicFont;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -129,6 +133,15 @@ public class PropertyTable extends GraphicalViewerImpl {
 		m_rowHeight = 1 + FigureUtilities.getFontMetrics(getControl().getFont()).getHeight() + 1;
 		// install tooltip helper
 		m_tooltipHelper = new PropertyTableTooltipHelper(this);
+		m_baseFont = parent.getFont();
+		m_boldFont = DrawUtils.getBoldFont(m_baseFont);
+		m_italicFont = DrawUtils.getItalicFont(m_baseFont);
+	}
+
+	@Override
+	protected void handleDispose(DisposeEvent e) {
+		m_boldFont.dispose();
+		m_italicFont.dispose();
 	}
 
 	@Override
@@ -969,9 +982,6 @@ public class PropertyTable extends GraphicalViewerImpl {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private boolean m_painting;
-	private Font m_baseFont;
-	private Font m_boldFont;
-	private Font m_italicFont;
 
 	/**
 	 * Handles {@link SWT#Paint} event.
@@ -1054,10 +1064,6 @@ public class PropertyTable extends GraphicalViewerImpl {
 	 */
 	private void drawContent(Graphics graphics) {
 		org.eclipse.swt.graphics.Rectangle clientArea = getControl().getClientArea();
-		// prepare fonts
-		m_baseFont = graphics.getFont();
-		m_boldFont = DrawUtils.getBoldFont(m_baseFont);
-		m_italicFont = DrawUtils.getItalicFont(m_baseFont);
 		// show presentations
 		int[] presentationsWidth = showPresentations(clientArea);
 		// draw properties
@@ -1094,9 +1100,6 @@ public class PropertyTable extends GraphicalViewerImpl {
 		// draw splitter
 		graphics.setForegroundColor(COLOR_LINE);
 		graphics.drawLine(m_splitter, 0, m_splitter, clientArea.height);
-		// dispose font
-		m_boldFont.dispose();
-		m_italicFont.dispose();
 	}
 
 	/**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
@@ -35,7 +35,6 @@ import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.ui.parts.GraphicalViewerImpl;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
-import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
@@ -645,19 +644,6 @@ public class PropertyTable extends GraphicalViewerImpl {
 	// ISelectionProvider
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private final List<ISelectionChangedListener> m_selectionListeners = new ArrayList<>();
-
-	@Override
-	public void addSelectionChangedListener(ISelectionChangedListener listener) {
-		if (!m_selectionListeners.contains(listener)) {
-			m_selectionListeners.add(listener);
-		}
-	}
-
-	@Override
-	public void removeSelectionChangedListener(ISelectionChangedListener listener) {
-		m_selectionListeners.add(listener);
-	}
 
 	@Override
 	public ISelection getSelection() {
@@ -697,10 +683,7 @@ public class PropertyTable extends GraphicalViewerImpl {
 			}
 		}
 		// send events
-		SelectionChangedEvent selectionEvent = new SelectionChangedEvent(this, getSelection());
-		for (ISelectionChangedListener listener : m_selectionListeners) {
-			listener.selectionChanged(selectionEvent);
-		}
+		fireSelectionChanged();
 		// re-draw
 		getControl().redraw();
 	}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTableTooltipHelper.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTableTooltipHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,7 +40,7 @@ class PropertyTableTooltipHelper implements IPropertyTooltipSite {
 	////////////////////////////////////////////////////////////////////////////
 	public PropertyTableTooltipHelper(PropertyTable table) {
 		m_table = table;
-		m_table.addListener(SWT.MouseHover, new Listener() {
+		m_table.getControl().addListener(SWT.MouseHover, new Listener() {
 			@Override
 			public void handleEvent(Event event) {
 				if (event.stateMask == 0) {
@@ -48,7 +48,7 @@ class PropertyTableTooltipHelper implements IPropertyTooltipSite {
 				}
 			}
 		});
-		m_table.addListener(SWT.MouseExit, new Listener() {
+		m_table.getControl().addListener(SWT.MouseExit, new Listener() {
 			@Override
 			public void handleEvent(Event event) {
 				// check, may be cursor is now on tooltip, so ignore this MouseExit
@@ -148,7 +148,7 @@ class PropertyTableTooltipHelper implements IPropertyTooltipSite {
 		}
 		// create Shell
 		{
-			m_tooltip = new Shell(m_table.getShell(), SWT.NO_FOCUS | SWT.ON_TOP | SWT.TOOL | SWT.SINGLE);
+			m_tooltip = new Shell(m_table.getControl().getShell(), SWT.NO_FOCUS | SWT.ON_TOP | SWT.TOOL | SWT.SINGLE);
 			configureColors(m_tooltip);
 			GridLayoutFactory.create(m_tooltip).noMargins();
 		}
@@ -163,9 +163,9 @@ class PropertyTableTooltipHelper implements IPropertyTooltipSite {
 			// prepare tooltip location
 			Point tooltipLocation;
 			if (provider.getTooltipPosition() == PropertyTooltipProvider.ON) {
-				tooltipLocation = m_table.toDisplay(new Point(startX, m_y));
+				tooltipLocation = m_table.getControl().toDisplay(new Point(startX, m_y));
 			} else {
-				tooltipLocation = m_table.toDisplay(new Point(startX, m_y + m_rowHeight));
+				tooltipLocation = m_table.getControl().toDisplay(new Point(startX, m_y + m_rowHeight));
 			}
 			// set location/size and open
 			m_tooltip.setLocation(tooltipLocation.x, tooltipLocation.y);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTooltipProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTooltipProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -99,12 +99,12 @@ public abstract class PropertyTooltipProvider {
 				// convert location from tooltip to table
 				Point p = new Point(event.x, event.y);
 				p = tooltipControl.toDisplay(p);
-				p = table.toControl(p);
+				p = table.getControl().toControl(p);
 				// send MouseDown to table
 				Event newEvent = new Event();
 				newEvent.x = p.x;
 				newEvent.y = p.y;
-				table.notifyListeners(SWT.MouseDown, newEvent);
+				table.getControl().notifyListeners(SWT.MouseDown, newEvent);
 				// hide tooltip
 				m_site.hideTooltip();
 				break;

--- a/org.eclipse.wb.layout.group/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.layout.group/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.layout.group;singleton:=true
-Bundle-Version: 1.9.500.qualifier
+Bundle-Version: 1.9.600.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/assistant/LayoutAssistantSupport.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/assistant/LayoutAssistantSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -108,7 +108,7 @@ public class LayoutAssistantSupport {
 		constraintsProperty.setEditorPresentation(new ButtonPropertyEditorPresentation() {
 			@Override
 			protected void onClick(PropertyTable propertyTable, Property property) throws Exception {
-				m_constraintsDialog = new ConstraintsDialog(propertyTable.getShell(), m_layout, component);
+				m_constraintsDialog = new ConstraintsDialog(propertyTable.getControl().getShell(), m_layout, component);
 				m_constraintsDialog.create();
 				m_constraintsDialog.getShell().addDisposeListener(new DisposeListener() {
 					@Override

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/viewers/TableViewerColumnSorterPropertyEditor.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/viewers/TableViewerColumnSorterPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,9 +24,9 @@ import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
 import org.eclipse.wb.internal.rcp.Activator;
 
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jface.viewers.TableViewer;
-import org.eclipse.swt.graphics.Point;
 
 /**
  * {@link PropertyEditor} for installing sorter of {@link TableViewer} by column.

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/CellConstraintsSupport.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/CellConstraintsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -529,7 +529,7 @@ public final class CellConstraintsSupport {
 			m_complexProperty.setEditorPresentation(new ButtonPropertyEditorPresentation() {
 				@Override
 				protected void onClick(PropertyTable propertyTable, Property property) throws Exception {
-					new CellEditDialog(propertyTable.getShell(), m_layout, m_this).open();
+					new CellEditDialog(propertyTable.getControl().getShell(), m_layout, m_this).open();
 				}
 			});
 			// grid properties

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/LayoutInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/LayoutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -276,7 +276,7 @@ public class LayoutInfo extends JavaInfo {
 								throws Exception {
 							MenuManager manager = new MenuManager();
 							getContainer().fillLayoutsManager(manager);
-							Menu menu = manager.createContextMenu(propertyTable);
+							Menu menu = manager.createContextMenu(propertyTable.getControl());
 							UiUtils.showAndDisposeOnHide(menu);
 						}
 					});

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/beans/TextPropertyEditor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/beans/TextPropertyEditor.java
@@ -20,7 +20,7 @@ import org.eclipse.wb.internal.core.model.property.editor.presentation.PropertyE
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 
 import org.eclipse.draw2d.Graphics;
-import org.eclipse.swt.graphics.Point;
+import org.eclipse.draw2d.geometry.Point;
 
 /**
  * The {@link PropertyEditor} wrapper for text based AWT {@link java.beans.PropertyEditor}.

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/color/ColorPropertyEditor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/color/ColorPropertyEditor.java
@@ -34,6 +34,7 @@ import org.eclipse.wb.internal.swing.model.ModelMessages;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.QualifiedName;
@@ -44,7 +45,6 @@ import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/LayoutInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/LayoutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -380,7 +380,7 @@ public class LayoutInfo extends JavaInfo implements ILayoutInfo<ControlInfo> {
 					protected void onClick(PropertyTable propertyTable, Property property) throws Exception {
 						MenuManager manager = new MenuManager();
 						getComposite().fillLayoutsManager(manager);
-						Menu menu = manager.createContextMenu(propertyTable);
+						Menu menu = manager.createContextMenu(propertyTable.getControl());
 						UiUtils.showAndDisposeOnHide(menu);
 					}
 				});

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/property/editor/color/ColorPropertyEditor.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/property/editor/color/ColorPropertyEditor.java
@@ -45,6 +45,7 @@ import org.eclipse.wb.internal.swt.support.SwtSupport;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.QualifiedName;
@@ -55,7 +56,6 @@ import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/EventsPropertyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/EventsPropertyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -2285,9 +2285,7 @@ public class EventsPropertyTest extends SwingModelTest implements IPreferenceCon
 		// open "keyPressed" method
 		{
 			PropertyEditor keyPressedEditor = keyPressedProperty.getEditor();
-			ReflectionUtils.invokeMethod(keyPressedEditor, "doubleClick("
-					+ Property.class.getName()
-					+ ",org.eclipse.swt.graphics.Point)", new Object[]{keyPressedProperty, null});
+			keyPressedEditor.doubleClick(keyPressedProperty, null);
 			assertEditor(
 					"class Test extends JPanel {",
 					"  Test() {",
@@ -2305,7 +2303,7 @@ public class EventsPropertyTest extends SwingModelTest implements IPreferenceCon
 
 	/**
 	 * Create listener method using
-	 * {@link PropertyEditor#activate(PropertyTable, Property, org.eclipse.swt.graphics.Point)}.
+	 * {@link PropertyEditor#activate(PropertyTable, Property, org.eclipse.draw2d.geometry.Point)}.
 	 */
 	@Test
 	public void test_ListenerMethodPropertyEditor_activate() throws Exception {
@@ -2324,11 +2322,7 @@ public class EventsPropertyTest extends SwingModelTest implements IPreferenceCon
 		// open "keyPressed" method
 		{
 			PropertyEditor keyPressedEditor = keyPressedProperty.getEditor();
-			ReflectionUtils.invokeMethod(keyPressedEditor, "activate("
-					+ PropertyTable.class.getName()
-					+ ","
-					+ Property.class.getName()
-					+ ",org.eclipse.swt.graphics.Point)", new Object[]{null, keyPressedProperty, null});
+			keyPressedEditor.activate(null, keyPressedProperty, null);
 			assertEditor(
 					"class Test extends JPanel {",
 					"  Test() {",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/BooleanObjectPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/BooleanObjectPropertyEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import org.eclipse.wb.internal.core.model.property.editor.BooleanPropertyEditor;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 
-import org.eclipse.swt.graphics.Point;
+import org.eclipse.draw2d.geometry.Point;
 
 import org.junit.Test;
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/BooleanPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/BooleanPropertyEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.wb.internal.core.model.property.editor.BooleanPropertyEditor;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 
-import org.eclipse.swt.graphics.Point;
+import org.eclipse.draw2d.geometry.Point;
 
 import org.junit.Test;
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/table/AbstractPropertyTableTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/table/AbstractPropertyTableTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,7 +47,7 @@ public abstract class AbstractPropertyTableTest extends DesignerTestCase {
 			m_shell.setBounds(10000, 0, 300, 500);
 			//
 			m_propertyTable = new PropertyTable(m_shell, SWT.NONE);
-			m_sender = new EventSender(m_propertyTable);
+			m_sender = new EventSender(m_propertyTable.getControl());
 			//
 			m_shell.setVisible(true);
 			waitEventLoop(1);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/table/PropertyTableTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/table/PropertyTableTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -100,16 +100,16 @@ public class PropertyTableTest extends AbstractPropertyTableTest {
 	@Test
 	public void test_cursor() throws Exception {
 		m_sender.moveTo(10, 10);
-		assertNull(m_propertyTable.getCursor());
+		assertNull(m_propertyTable.getControl().getCursor());
 		//
 		int splitter = m_propertyTable.forTests_getSplitter();
 		for (int x = splitter - 1; x <= splitter + 1; x++) {
 			m_sender.moveTo(x, 10);
-			assertSame(Cursors.SIZEWE, m_propertyTable.getCursor());
+			assertSame(Cursors.SIZEWE, m_propertyTable.getControl().getCursor());
 		}
 		//
 		m_sender.moveTo(splitter + 2, 10);
-		assertNull(m_propertyTable.getCursor());
+		assertNull(m_propertyTable.getControl().getCursor());
 	}
 
 	/**
@@ -117,7 +117,7 @@ public class PropertyTableTest extends AbstractPropertyTableTest {
 	 */
 	@Test
 	public void test_splitter() throws Exception {
-		int width = m_propertyTable.getClientArea().width;
+		int width = m_propertyTable.getControl().getClientArea().width;
 		// check initial position
 		int splitter = (int) (width * 0.4);
 		assertEquals(splitter, m_propertyTable.forTests_getSplitter());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/table/TableTest1.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/table/TableTest1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -85,7 +85,7 @@ public class TableTest1 {
 		PropertyTable table = new PropertyTable(shell, SWT.NONE);
 		//PropertyTable2 table = new PropertyTable2(shell, SWT.NONE);
 		//table.setFont(new Font(null, "", 12, SWT.NONE));
-		table.setLayoutData(new GridData(GridData.FILL_BOTH));
+		table.getControl().setLayoutData(new GridData(GridData.FILL_BOTH));
 		//table.setInput(null);
 		if (true) {
 			table.setInput(new Property[]{

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import org.eclipse.wb.internal.core.editor.DesignPageSite;
 import org.eclipse.wb.internal.core.editor.actions.DesignPageActions;
 import org.eclipse.wb.internal.core.editor.multi.DesignerEditor;
 import org.eclipse.wb.internal.core.editor.palette.DesignerPalette;
+import org.eclipse.wb.internal.core.editor.structure.DesignComponentsComposite;
 import org.eclipse.wb.internal.core.editor.structure.components.IComponentsTree;
 import org.eclipse.wb.internal.core.gef.part.DesignRootEditPart;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
@@ -257,7 +258,9 @@ public abstract class DesignerEditorTestCase extends AbstractJavaInfoRelatedTest
 		{
 			UiContext uiContext = new UiContext();
 			uiContext.useShell(DesignerPlugin.getShell().getText());
-			m_propertyTable = uiContext.findFirstWidget(PropertyTable.class);
+			Object componentComposite = uiContext.findFirstWidget(DesignComponentsComposite.class);
+			Object componentPropertyPage = ReflectionUtils.getFieldObject(componentComposite, "m_propertiesPage");
+			m_propertyTable = (PropertyTable) ReflectionUtils.getFieldObject(componentPropertyPage, "m_propertyTable");
 		}
 		// DesignPageSite
 		{

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EventSender.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EventSender.java
@@ -130,7 +130,7 @@ public class EventSender {
 		Event event = createEvent(x, y, 0);
 		m_control.notifyListeners(SWT.MouseMove, event);
 		// process "async" runnables
-		waitEventLoop(0);
+		waitEventLoop(10);
 		return this;
 	}
 

--- a/target-platform/wb.target
+++ b/target-platform/wb.target
@@ -4,6 +4,7 @@
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/releases/2024-06/"/>
+			<repository location="https://download.eclipse.org/tools/gef/classic/nightly/latest/"/>
 			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>


### PR DESCRIPTION
With this change, the PropertyTable extends GraphicalViewerImpl rather than Canvas. Note that the viewer doesn't use any figures yet and paints directly on the underlying FigureCanvas.

Because we manage scrolling on our own, for the time being, we can't extends ScrollingGraphicalViewer.