### PR TITLE
Add required "actions" read permission to unit-test-result jobs

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       checks: write
       pull-requests: write
+      actions: read
 
     steps:
       - name: Download and Extract Artifacts


### PR DESCRIPTION
This permission is required for the "publish test results" task to complete in case pull requests come from a forked repository.